### PR TITLE
convert links to url and resolve relative links

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,9 @@ module.exports = function run(link, args = []) {
     throw err
   }
   const { key, fork, length } = parsed.drive
-  const { key: appKey } = Pear.app.applink
-    ? plink.parse(Pear.app.applink).drive
-    : {}
+
+  const applink = plink.parse(Pear.app.applink)
+  const { key: appKey } = applink.drive
   if (
     appKey &&
     key &&
@@ -45,21 +45,13 @@ module.exports = function run(link, args = []) {
   }
 
   if (isPath) {
-    if (Pear.app.key !== null) {
-      if (isAbsolute) {
-        link = Pear.app.link + link
-      } else {
-        unixpathresolve('/', link) // check that the link doesnt escape project root
-        link = `pear://${unixpathresolve('/' + Pear.app.link.substring('pear://'.length), link).slice(1)}`
-      }
-    } else {
-      if (isAbsolute) {
-        link = pathToFileURL(link).href
-      } else {
-        unixpathresolve('/', link) // check that the link doesnt escape project root
-        link = pathToFileURL(path.resolve(Pear.app.dir, link)).href
-      }
-    }
+    unixpathresolve('/', link) // throw if escaping root
+    if (isAbsolute) link = pathToFileURL(link)
+    else
+      link = plink.serialize({
+        ...applink,
+        pathname: unixpathresolve(applink.pathname || '/', link)
+      })
   }
 
   const argv = pear(program.argv.slice(1)).rest

--- a/index.js
+++ b/index.js
@@ -46,7 +46,8 @@ module.exports = function run(link, args = []) {
 
   if (isPath) {
     unixpathresolve('/', link) // throw if escaping root
-    if (isAbsolute) link = pathToFileURL(link)
+    if (isAbsolute)
+      link = Pear.app.key === null ? pathToFileURL(link) : applink.origin + link
     else
       link = plink.serialize({
         ...applink,

--- a/index.js
+++ b/index.js
@@ -46,8 +46,7 @@ module.exports = function run(link, args = []) {
 
   if (isPath) {
     unixpathresolve('/', link) // throw if escaping root
-    if (isAbsolute)
-      link = Pear.app.key === null ? pathToFileURL(link) : applink.origin + link
+    if (isAbsolute) link = pathToFileURL(link)
     else
       link = plink.serialize({
         ...applink,

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function run(link, args = []) {
 
   if (isPath) {
     unixpathresolve('/', link) // throw if escaping root
-    if (isAbsolute) link = pathToFileURL(link)
+    if (isAbsolute) link = pathToFileURL(link).href.replaceAll('%23', '#')
     else
       link = plink.serialize({
         ...applink,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "pear-link": "^4.1.0",
     "pear-ref": "^1.0.0",
     "unix-path-resolve": "^1.0.2",
-    "url-file-url": "^1.0.5"
+    "url-file-url": "^1.0.5",
+    "which-runtime": "^1.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "brittle": "^3.0.0",
     "pear-api": "^1.28.8",
     "pear-pipe": "^1.0.0",
+    "prettier": "^3.6.2",
+    "prettier-config-holepunch": "^1.0.0",
     "standard": "^17.1.2"
   },
   "dependencies": {
@@ -33,8 +35,7 @@
     "pear-cmd": "^1.0.0",
     "pear-link": "^4.1.0",
     "pear-ref": "^1.0.0",
-    "prettier": "^3.6.2",
-    "prettier-config-holepunch": "^1.0.0",
-    "unix-path-resolve": "^1.0.2"
+    "unix-path-resolve": "^1.0.2",
+    "url-file-url": "^1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "pear-link": "^4.1.0",
     "pear-ref": "^1.0.0",
     "prettier": "^3.6.2",
-    "prettier-config-holepunch": "^1.0.0"
+    "prettier-config-holepunch": "^1.0.0",
+    "unix-path-resolve": "^1.0.2"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,6 +3,7 @@
 const test = require('brittle')
 const path = require('bare-path')
 const os = require('bare-os')
+const { pathToFileURL } = require('url-file-url')
 global.Pear = {}
 const run = require('..')
 os.chdir(__dirname)
@@ -19,7 +20,7 @@ test('returns a pipe that talks to the sub app', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = {}
+    app = { key: null }
   }
   global.Pear = new API()
   const link = fixtures.echo
@@ -45,7 +46,7 @@ test('injects --trusted flag into argv', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = {}
+    app = { key: null }
   }
   global.Pear = new API()
   const link = fixtures.argv
@@ -60,7 +61,7 @@ test('injects --trusted flag into argv', (t) => {
   const pipe = run(link)
   pipe.once('data', (data) => {
     const childArgv = JSON.parse(data)
-    t.is(childArgv[2], '--trusted')
+    t.is(childArgv[4], '--trusted')
   })
 })
 
@@ -91,13 +92,201 @@ test('when from disk, injects --base flag into argv', (t) => {
   })
 })
 
+test('relative path cant escape app key', (t) => {
+  t.plan(1)
+
+  class API {
+    static RUNTIME = global.Bare.argv[0]
+    static RTI = {}
+    static RUNTIME_ARGV = []
+    app = { key: Buffer.alloc(32), link: 'pear://key' }
+  }
+  global.Pear = new API()
+  const link = '../foo'
+  global.Bare.argv.length = 1
+  global.Bare.argv.push('run', link)
+  try {
+    run(link)
+  } catch (err) {
+    t.is(err.message, `Path cannot be resolved, too many '..'`)
+  }
+})
+
+test('relative path cant escape app dir', (t) => {
+  t.plan(3)
+
+  class API {
+    static RUNTIME = global.Bare.argv[0]
+    static RTI = {}
+    static RUNTIME_ARGV = []
+    app = { key: null, dir: __dirname }
+  }
+  try {
+    global.Pear = new API()
+    global.Bare.argv.length = 1
+    const link = '../foo'
+    global.Bare.argv.push('run', link)
+    run(link)
+  } catch (err) {
+    t.is(err.message, `Path cannot be resolved, too many '..'`)
+  }
+
+  try {
+    global.Pear = new API()
+    global.Bare.argv.length = 1
+    const link = './../foo'
+    global.Bare.argv.push('run', link)
+    run(link)
+  } catch (err) {
+    t.is(err.message, `Path cannot be resolved, too many '..'`)
+  }
+
+  try {
+    global.Pear = new API()
+    global.Bare.argv.length = 1
+    const link = './bar/../../foo'
+    global.Bare.argv.push('run', link)
+    run(link)
+  } catch (err) {
+    t.is(err.message, `Path cannot be resolved, too many '..'`)
+  }
+})
+
+test('absolute path is converted to file url ', (t) => {
+  t.plan(1)
+
+  class API {
+    static RUNTIME = global.Bare.argv[0]
+    static RTI = {}
+    static RUNTIME_ARGV = []
+    app = { dir: __dirname, key: null }
+  }
+  global.Pear = new API()
+  const link = path.join(__dirname, 'foo', 'bar')
+  global.Bare.argv.length = 1
+  global.Bare.argv.push('run', link)
+  t.teardown(() => {
+    delete global.Pear
+    global.Bare.argv.length = 1
+    global.Bare.argv.push(...ARGV)
+    pipe.end()
+  })
+  const pipe = run(link)
+  pipe.once('data', (data) => {
+    const childArgv = JSON.parse(data)
+    const path = childArgv[5]
+    t.is(
+      path,
+      pathToFileURL(__dirname) + '/foo/bar',
+      'absolute path is coverted to file url'
+    )
+  })
+})
+
+test('relative path is relative to project root', (t) => {
+  t.plan(1)
+
+  class API {
+    static RUNTIME = global.Bare.argv[0]
+    static RTI = {}
+    static RUNTIME_ARGV = []
+    app = { dir: __dirname, key: null }
+  }
+  global.Pear = new API()
+  const link = './foo/bar'
+  global.Bare.argv.length = 1
+  global.Bare.argv.push('run', link)
+  t.teardown(() => {
+    delete global.Pear
+    global.Bare.argv.length = 1
+    global.Bare.argv.push(...ARGV)
+    pipe.end()
+  })
+  const pipe = run(link)
+  pipe.once('data', (data) => {
+    const childArgv = JSON.parse(data)
+    const path = childArgv[5]
+    t.is(
+      path,
+      pathToFileURL(__dirname) + '/foo/bar',
+      'relative path is resolved from project root'
+    )
+  })
+})
+
+test('relative path is relative to link with app-key', (t) => {
+  t.plan(1)
+
+  class API {
+    static RUNTIME = global.Bare.argv[0]
+    static RTI = {}
+    static RUNTIME_ARGV = []
+    app = {
+      key: Buffer.alloc(32),
+      link: 'pear://key',
+      dir: __dirname
+    }
+  }
+  global.Pear = new API()
+  const link = './foo/bar'
+  global.Bare.argv.length = 1
+  global.Bare.argv.push('run', link)
+  t.teardown(() => {
+    delete global.Pear
+    global.Bare.argv.length = 1
+    global.Bare.argv.push(...ARGV)
+    pipe.end()
+  })
+  const pipe = run(link)
+  pipe.once('data', (data) => {
+    const childArgv = JSON.parse(data)
+    const path = childArgv[3]
+    t.is(
+      path,
+      `pear://key/foo/bar`,
+      'relative path is resolved from link with app-key'
+    )
+  })
+})
+
+test('when running from key absolute path is appended to link', (t) => {
+  t.plan(1)
+
+  class API {
+    static RUNTIME = global.Bare.argv[0]
+    static RTI = {}
+    static RUNTIME_ARGV = []
+    app = {
+      key: Buffer.alloc(32),
+      link: 'pear://key/foo',
+      dir: __dirname
+    }
+  }
+  global.Pear = new API()
+  const link = '/bar/baz'
+  global.Bare.argv.length = 1
+  global.Bare.argv.push('run', link)
+  t.teardown(() => {
+    delete global.Pear
+    global.Bare.argv.length = 1
+    global.Bare.argv.push(...ARGV)
+    pipe.end()
+  })
+  const pipe = run(link)
+  pipe.once('data', (data) => {
+    const childArgv = JSON.parse(data)
+    const path = childArgv[3]
+    t.is(path, `pear://key/foo/bar/baz`, 'absolute path is appended to link')
+  })
+})
+
 test('avoids --trusted flag duplication', (t) => {
   t.plan(1)
   class API {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = {}
+    app = { key: null }
   }
   global.Pear = new API()
   const link = fixtures.argv
@@ -123,7 +312,7 @@ test('injects --parent when RTI.startId is set', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = { startId: 'de4215533cd3343ed3331111245abf' }
     static RUNTIME_ARGV = []
-    app = {}
+    app = { key: null }
   }
   global.Pear = new API()
   const link = fixtures.argv
@@ -150,7 +339,7 @@ test('passes args input at the tail', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = {}
+    app = { key: null }
   }
   global.Pear = new API()
   const link = fixtures.argv
@@ -178,7 +367,7 @@ test('passes Pear.constructor.RUNTIME_ARGV at the head', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = ['alt-run', 'some', 'args']
-    app = {}
+    app = { key: null, dir: __dirname }
   }
   global.Pear = new API()
   const link = fixtures.argv
@@ -198,8 +387,10 @@ test('passes Pear.constructor.RUNTIME_ARGV at the head', (t) => {
       'some',
       'args',
       'run',
+      '--base',
+      __dirname,
       '--trusted',
-      fixtures.argv,
+      pathToFileURL(link).href,
       '--foo',
       'bar'
     ])
@@ -212,7 +403,7 @@ test('pipe emits crash event on non-zero child exit', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = {}
+    app = { key: null }
   }
   global.Pear = new API()
   const link = fixtures.nonZeroExit
@@ -303,7 +494,7 @@ test('normalizes pear://dev link to relative path', (t) => {
     static RUNTIME = Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = {}
+    app = { key: null, dir: __dirname }
   }
   global.Pear = new API()
 
@@ -333,7 +524,7 @@ test('splices out --links <value>', (t) => {
     static RUNTIME = Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = {}
+    app = { key: null, dir: __dirname }
   }
   global.Pear = new API()
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,7 +21,7 @@ test('returns a pipe that talks to the sub app', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = { key: null }
+    app = { key: null, applink: pathToFileURL(__dirname).href }
   }
   global.Pear = new API()
   const link = fixtures.echo
@@ -47,7 +47,7 @@ test('injects --trusted flag into argv', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = { key: null }
+    app = { key: null, applink: pathToFileURL(__dirname).href }
   }
   global.Pear = new API()
   const link = fixtures.argv
@@ -73,7 +73,7 @@ test('when from disk, injects --base flag into argv', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = { dir: __dirname, key: null }
+    app = { applink: pathToFileURL(__dirname).href, key: null, dir: __dirname }
   }
   global.Pear = new API()
   const link = !isWindows ? './fixtures/argv.js' : '.\\fixtures\\argv.js'
@@ -100,7 +100,7 @@ test('relative path cant escape app key', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = { key: Buffer.alloc(32), link: 'pear://key' }
+    app = { key: Buffer.alloc(32), applink: 'pear://keet', dir: __dirname }
   }
   global.Pear = new API()
   const link = '../foo'
@@ -113,14 +113,14 @@ test('relative path cant escape app key', (t) => {
   }
 })
 
-test('relative path cant escape app dir', (t) => {
+test('relative path cant escape project root', (t) => {
   t.plan(3)
 
   class API {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = { key: null, dir: __dirname }
+    app = { key: null, applink: pathToFileURL(__dirname).href, dir: __dirname }
   }
   try {
     global.Pear = new API()
@@ -160,7 +160,7 @@ test('absolute path is converted to file url ', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = { dir: __dirname, key: null }
+    app = { applink: pathToFileURL(__dirname).href, key: null }
   }
   global.Pear = new API()
   const link = path.join(__dirname, 'foo', 'bar')
@@ -178,7 +178,7 @@ test('absolute path is converted to file url ', (t) => {
     const path = childArgv[3]
     t.is(
       path,
-      pathToFileURL(__dirname) + '/foo/bar',
+      pathToFileURL(__dirname).href + '/foo/bar',
       'absolute path is coverted to file url'
     )
   })
@@ -191,7 +191,7 @@ test('relative path is relative to project root', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = { dir: __dirname, key: null }
+    app = { applink: pathToFileURL(__dirname).href, key: null }
   }
   global.Pear = new API()
   const link = './foo/bar'
@@ -209,7 +209,7 @@ test('relative path is relative to project root', (t) => {
     const path = childArgv[5]
     t.is(
       path,
-      pathToFileURL(__dirname) + '/foo/bar',
+      pathToFileURL(__dirname).href + '/foo/bar',
       'relative path is resolved from project root'
     )
   })
@@ -224,8 +224,8 @@ test('relative path is relative to link with app-key', (t) => {
     static RUNTIME_ARGV = []
     app = {
       key: Buffer.alloc(32),
-      link: 'pear://key',
-      dir: __dirname
+      applink: 'pear://key',
+      applink: pathToFileURL(__dirname).href
     }
   }
   global.Pear = new API()
@@ -259,8 +259,8 @@ test('when running from key absolute path is appended to link', (t) => {
     static RUNTIME_ARGV = []
     app = {
       key: Buffer.alloc(32),
-      link: 'pear://key/foo',
-      dir: __dirname
+      applink: 'pear://key/foo',
+      applink: pathToFileURL(__dirname).href
     }
   }
   global.Pear = new API()
@@ -287,7 +287,7 @@ test('avoids --trusted flag duplication', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = { key: null }
+    app = { key: null, applink: pathToFileURL(__dirname).href }
   }
   global.Pear = new API()
   const link = fixtures.argv
@@ -313,7 +313,7 @@ test('injects --parent when RTI.startId is set', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = { startId: 'de4215533cd3343ed3331111245abf' }
     static RUNTIME_ARGV = []
-    app = { key: null }
+    app = { key: null, applink: pathToFileURL(__dirname).href }
   }
   global.Pear = new API()
   const link = fixtures.argv
@@ -340,7 +340,7 @@ test('passes args input at the tail', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = { key: null }
+    app = { key: null, applink: pathToFileURL(__dirname).href }
   }
   global.Pear = new API()
   const link = fixtures.argv
@@ -368,7 +368,7 @@ test('passes Pear.constructor.RUNTIME_ARGV at the head', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = ['alt-run', 'some', 'args']
-    app = { key: null, dir: __dirname }
+    app = { key: null, applink: pathToFileURL(__dirname).href }
   }
   global.Pear = new API()
   const link = fixtures.argv
@@ -402,7 +402,7 @@ test('pipe emits crash event on non-zero child exit', (t) => {
     static RUNTIME = global.Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = { key: null }
+    app = { key: null, applink: pathToFileURL(__dirname).href }
   }
   global.Pear = new API()
   const link = fixtures.nonZeroExit
@@ -493,7 +493,7 @@ test('normalizes pear://dev link to relative path', (t) => {
     static RUNTIME = Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = { key: null, dir: __dirname }
+    app = { key: null, applink: pathToFileURL(__dirname).href }
   }
   global.Pear = new API()
 
@@ -523,7 +523,7 @@ test('splices out --links <value>', (t) => {
     static RUNTIME = Bare.argv[0]
     static RTI = {}
     static RUNTIME_ARGV = []
-    app = { key: null, dir: __dirname }
+    app = { key: null, applink: pathToFileURL(__dirname).href }
   }
   global.Pear = new API()
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -224,8 +224,7 @@ test('relative path is relative to link with app-key', (t) => {
     static RUNTIME_ARGV = []
     app = {
       key: Buffer.alloc(32),
-      applink: 'pear://key',
-      applink: pathToFileURL(__dirname).href
+      applink: 'pear://keet'
     }
   }
   global.Pear = new API()
@@ -244,7 +243,7 @@ test('relative path is relative to link with app-key', (t) => {
     const path = childArgv[3]
     t.is(
       path,
-      `pear://key/foo/bar`,
+      'pear://keet/foo/bar',
       'relative path is resolved from link with app-key'
     )
   })
@@ -259,8 +258,7 @@ test('when running from key absolute path is appended to link', (t) => {
     static RUNTIME_ARGV = []
     app = {
       key: Buffer.alloc(32),
-      applink: 'pear://key/foo',
-      applink: pathToFileURL(__dirname).href
+      applink: 'pear://keet'
     }
   }
   global.Pear = new API()
@@ -277,7 +275,7 @@ test('when running from key absolute path is appended to link', (t) => {
   pipe.once('data', (data) => {
     const childArgv = JSON.parse(data)
     const path = childArgv[3]
-    t.is(path, `pear://key/foo/bar/baz`, 'absolute path is appended to link')
+    t.is(path, `pear://keet/bar/baz`, 'absolute path is appended to link')
   })
 })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -275,7 +275,7 @@ test('when running from key absolute path is file url', (t) => {
   pipe.once('data', (data) => {
     const childArgv = JSON.parse(data)
     const path = childArgv[3]
-    t.is(path, `file:///bar/baz`, 'absolute path is file url')
+    t.is(path, pathToFileURL('/bar/baz').href, 'absolute path is file url')
   })
 })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,7 @@ const test = require('brittle')
 const path = require('bare-path')
 const os = require('bare-os')
 const { pathToFileURL } = require('url-file-url')
+const { isWindows } = require('which-runtime')
 global.Pear = {}
 const run = require('..')
 os.chdir(__dirname)
@@ -61,7 +62,7 @@ test('injects --trusted flag into argv', (t) => {
   const pipe = run(link)
   pipe.once('data', (data) => {
     const childArgv = JSON.parse(data)
-    t.is(childArgv[4], '--trusted')
+    t.is(childArgv[2], '--trusted')
   })
 })
 
@@ -75,7 +76,7 @@ test('when from disk, injects --base flag into argv', (t) => {
     app = { dir: __dirname, key: null }
   }
   global.Pear = new API()
-  const link = fixtures.argv
+  const link = !isWindows ? './fixtures/argv.js' : '.\\fixtures\\argv.js'
   global.Bare.argv.length = 1
   global.Bare.argv.push('run', link)
   t.teardown(() => {
@@ -174,7 +175,7 @@ test('absolute path is converted to file url ', (t) => {
   const pipe = run(link)
   pipe.once('data', (data) => {
     const childArgv = JSON.parse(data)
-    const path = childArgv[5]
+    const path = childArgv[3]
     t.is(
       path,
       pathToFileURL(__dirname) + '/foo/bar',
@@ -387,8 +388,6 @@ test('passes Pear.constructor.RUNTIME_ARGV at the head', (t) => {
       'some',
       'args',
       'run',
-      '--base',
-      __dirname,
       '--trusted',
       pathToFileURL(link).href,
       '--foo',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -93,7 +93,7 @@ test('when from disk, injects --base flag into argv', (t) => {
   })
 })
 
-test('relative path cant escape app key', (t) => {
+test('relative path cannot escape app key', (t) => {
   t.plan(1)
 
   class API {
@@ -113,7 +113,7 @@ test('relative path cant escape app key', (t) => {
   }
 })
 
-test('relative path cant escape project root', (t) => {
+test('relative path cannot escape project root', (t) => {
   t.plan(3)
 
   class API {
@@ -249,7 +249,7 @@ test('relative path is relative to link with app-key', (t) => {
   })
 })
 
-test('when running from key absolute path is appended to link', (t) => {
+test('when running from key absolute path is file url', (t) => {
   t.plan(1)
 
   class API {
@@ -275,7 +275,7 @@ test('when running from key absolute path is appended to link', (t) => {
   pipe.once('data', (data) => {
     const childArgv = JSON.parse(data)
     const path = childArgv[3]
-    t.is(path, `pear://keet/bar/baz`, 'absolute path is appended to link')
+    t.is(path, `file:///bar/baz`, 'absolute path is file url')
   })
 })
 


### PR DESCRIPTION
This PR improves how paths are resolved when running an app or project. It ensures consistent and secure handling of both relative and absolute paths depending on whether the runtime is using an app key (pear://...) or a project root directory.

**Absolute path handling**

Absolute filesystem paths are converted into file:// URLs when running from a project root. When running with an app key, absolute paths are converted to file urls.

**Relative path handling**

When running from a project root (no app key): relative paths are resolved against the project’s root directory and converted into file:// URLs.
When running with an app key: relative paths are resolved against the app’s pear:// link.

**Path traversal prevention**

Relative paths that attempt to escape the app key or project root with .. are rejected with a clear error:
`Path cannot be resolved, too many '..'`

(edit: updated table)

 **Input**   | **Result**                          |
-------------|-------------------------------------|
| `/a/b`      | `file://a/b`                    |
| `./a/b`    | `pear://key/a/b` OR `file://<root>/a/b`                    |
| `../a/b`   | *`Path cannot be resolved, too many ..`* |


