### PR TITLE
add flags parameter to run function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 import run from 'pear-run'
 ```
 
-### `run(link[, args]) -> pipe`
+### `run(link[, args[, flags]]) -> pipe`
 
 Launch a Pear application in a subprocess peer-to-peer or from disk by link.
 
@@ -23,6 +23,10 @@ A `pear://` link, `file://` link or relative path.
 #### `args <string[]> (optional)`
 
 Additional arguments to append to the runtime invocation after the link.
+
+#### `flags <string[]> (optional)`
+
+Additional flags to append to the runtime invocation before the link.
 
 # License
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const { isElectronRenderer } = require('which-runtime')
 const unixpathresolve = require('unix-path-resolve')
 const program = global.Bare ?? global.process
 
-module.exports = function run(link, args = []) {
+module.exports = function run(link, args = [], flags = []) {
   const isPear = link.startsWith('pear://')
   const isFile = link.startsWith('file://')
   const isPath = isPear === false && isFile === false
@@ -67,7 +67,7 @@ module.exports = function run(link, args = []) {
   const argv = pear(program.argv.slice(1)).rest
   const parser = command('run', ...rundef)
   const cmd = parser.parse(argv, { sync: true })
-  const inject = ['--no-pre', link]
+  const inject = [...flags, '--no-pre', link]
   if (!cmd.flags.trusted) inject.unshift('--trusted')
   if (RTI.startId) inject.unshift('--parent', RTI.startId)
   if (


### PR DESCRIPTION
Making this change in order to test the `--preflight` flag in pear, which gets swallowed when passed into args due to the rest definition [here](https://github.com/holepunchto/pear-cmd/blob/main/run.js#L6). 
